### PR TITLE
Feat : 소셜로그인 사용자 정보 가져오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
 
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
+    implementation 'com.google.code.gson:gson:2.8.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
@@ -72,13 +72,12 @@ public class MemberService {
 
     // 소셜 로그인
     @Transactional
-    public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String email, String name) {
+    public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String email, String name, String nickname) {
         Optional<Member> opMember = findByUsername(username);
 
         if (opMember.isPresent()) return RsData.of("S-1", "로그인 되었습니다.", opMember.get());
 
-        return join(providerTypeCode, username, "", email, name, ""); // 최초 로그인시 실행
-        //TODO : 닉네임 설정
+        return join(providerTypeCode, username, "", email, name, nickname); // 최초 로그인시 실행
 
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
       client:
         registration:
           kakao:
-            scope:
+            scope: account_email, profile_nickname
             client-name: Kakao
             authorization-grant-type: authorization_code
             redirect-uri: https://localhost:8080/login/oauth2/code/kakao
@@ -35,7 +35,7 @@ spring:
           google:
             redirect-uri: https://localhost:8080/login/oauth2/code/google
             client-name: Google
-            scope: profile
+            scope: profile, email
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/templates/usr/member/me.html
+++ b/src/main/resources/templates/usr/member/me.html
@@ -24,8 +24,20 @@
                     </h2>
                     <table class="table w-full">
                         <tr>
-                            <td>계정</td>
+                            <td>아이디</td>
                             <td><span th:text="${@rq.member.username}"></span></td>
+                        </tr>
+                        <tr>
+                            <td>이름</td>
+                            <td><span th:text="${@rq.member.name}"></span></td>
+                        </tr>
+                        <tr>
+                            <td>닉네임</td>
+                            <td><span th:text="${@rq.member.nickname}"></span></td>
+                        </tr>
+                        <tr>
+                            <td>이메일</td>
+                            <td><span th:text="${@rq.member.email}"></span></td>
                         </tr>
                         <tr>
                             <td>가입날짜</td>


### PR DESCRIPTION
#### 추가된 내용
- 카카오, 구글, 네이버 소셜 로그인에서 사용자 정보 가져오기

#### 변경사항
- application.yml에 scope 추가

#### 특이사항
- 카카오 
  - 이름, 닉네임, 이메일
- 구글 
  - 이름, 이메일
  - 등록된 닉네임 없음
- 네이버 
  - 닉네임, 이메일
  - 이름은 권한없음으로 불러오지 못함 / 추후에 카카오 앱 비즈앱으로 전환 후 가져올 수 있음
  - 임시로 닉네임을 이름으로 가져오도록

close #28
