### PR TITLE
Feat : 회원가입 중복 체크, 닉네임 수정

### DIFF
--- a/src/main/java/com/placehub/base/initData/NotProd.java
+++ b/src/main/java/com/placehub/base/initData/NotProd.java
@@ -32,7 +32,7 @@ public class NotProd {
                 Member member1 = memberService.join("user1", "1234", "123@123", "이름1", "닉네임1").getData();
                 Member member2 = memberService.join("user2", "1234", "234@234", "이름2", "닉네임2").getData();
 
-                Member memberJinyeongKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2812333976", "pjy100402@naver.com", "박진영", "박진영").getData();
+                Member memberJinyeongKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2812333976", "pjy100402@naver.com", "박진영", "KAKAO__2812333976").getData();
 
                 Member memberAdmin = memberService.create("admin", "1234", "user1", "user1@gmail.com", "user1Nick");
 

--- a/src/main/java/com/placehub/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/placehub/base/security/CustomOAuth2UserService.java
@@ -35,7 +35,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String email = "";
         String name = "";
-        String nickname = "";
 
         if (providerTypeCode.equals("KAKAO")) {
 
@@ -43,7 +42,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             email = extractValue(userInfo, "email");
 
             Map<String, Object> profile = extractValue(userInfo, "profile");
-            nickname = extractValue(profile, "nickname");
 
             // 사용자 이름 - 개발 단계에선 권한 없음으로 불러오기 불가 - 임시로 닉네임과 동일하게 설정
             // TODO : 카카오 비즈앱 전환 후 이름 가져오기 권한 받고 수정해야함
@@ -57,7 +55,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             oauthId = userInfo.get("id");
             name = userInfo.get("name");
             email = userInfo.get("email");
-            nickname = userInfo.get("nickname");
 
         }
 
@@ -67,6 +64,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
 
         String username = providerTypeCode + "__%s".formatted(oauthId);
+        String nickname = providerTypeCode + "__%s".formatted(oauthId); // 소셜로그인 시 닉네임은 username과 동일하게
 
         Member member = memberService.whenSocialLogin(providerTypeCode, username, email, name, nickname).getData();
 

--- a/src/main/java/com/placehub/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/placehub/boundedContext/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.placehub.boundedContext.member.controller;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.placehub.base.rq.Rq;
 import com.placehub.base.rsData.RsData;
 import com.placehub.base.util.Ut;
@@ -14,12 +15,12 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/member")
@@ -27,6 +28,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class MemberController {
     private final MemberService memberService;
     private final Rq rq;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @PreAuthorize("isAnonymous()")
     @GetMapping("/join")
@@ -65,6 +69,20 @@ public class MemberController {
         String msg = joinRs.getMsg() + "\n로그인 후 이용해주세요.";
 
         return rq.redirectWithMsg("/member/login", joinRs);
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/update/nickname/{id}")
+    public ResponseEntity<String> updateNickname(@PathVariable Long id ,@RequestParam("nickname") String nickname) {
+        Member member = rq.getMember();
+
+        RsData updateRsData = memberService.updateNickname(member, id, nickname);
+
+        if(updateRsData.isFail()){
+            return ResponseEntity.badRequest().body("{\"message\": \"" + updateRsData.getMsg() + "\"}");
+        }
+
+        return ResponseEntity.ok().body("{\"message\": \"닉네임이 %s(으)로 수정되었습니다.\"}".formatted(nickname));
     }
 
 

--- a/src/main/java/com/placehub/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/placehub/boundedContext/member/controller/MemberController.java
@@ -54,12 +54,13 @@ public class MemberController {
     @PostMapping("/join")
     public String join(@Valid JoinForm joinForm) {
 
-        RsData<Member> joinRs = memberService.join(joinForm.getUsername(), joinForm.getPassword(),joinForm.getEmail(),joinForm.getName(),joinForm.getNickname());
+        RsData<Member> checkRsData = memberService.checkDuplicateValue(joinForm.getUsername(), joinForm.getEmail(), joinForm.getNickname());
 
-        if (joinRs.isFail()) {
-            return rq.historyBack(joinRs.getMsg());
-
+        if (checkRsData.isFail()) {
+            return rq.historyBack(checkRsData.getMsg());
         }
+
+        RsData<Member> joinRs = memberService.join(joinForm.getUsername(), joinForm.getPassword(),joinForm.getEmail(),joinForm.getName(),joinForm.getNickname());
 
         String msg = joinRs.getMsg() + "\n로그인 후 이용해주세요.";
 

--- a/src/main/java/com/placehub/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/placehub/boundedContext/member/entity/Member.java
@@ -25,7 +25,9 @@ public class Member extends BaseEntity {
     private String username;
     private String password;
     private String name;
+    @Column(unique = true)
     private String email;
+    @Column(unique = true)
     private String nickname;
 
     public List<? extends GrantedAuthority> getGrantedAuthorities() {

--- a/src/main/java/com/placehub/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/placehub/boundedContext/member/entity/Member.java
@@ -25,7 +25,7 @@ public class Member extends BaseEntity {
     private String username;
     private String password;
     private String name;
-    @Column(unique = true)
+
     private String email;
     @Column(unique = true)
     private String nickname;

--- a/src/main/java/com/placehub/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/placehub/boundedContext/member/entity/Member.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.GrantedAuthority;
@@ -27,6 +28,8 @@ public class Member extends BaseEntity {
     private String name;
 
     private String email;
+
+    @Setter
     @Column(unique = true)
     private String nickname;
 

--- a/src/main/java/com/placehub/boundedContext/member/repository/MemberRepository.java
+++ b/src/main/java/com/placehub/boundedContext/member/repository/MemberRepository.java
@@ -8,5 +8,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByNickname(String nickname);
 
 }

--- a/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
@@ -89,6 +89,25 @@ public class MemberService {
     }
 
 
+    public RsData<Member> updateNickname(Member actor, Long memberId, String nickname) {
+
+        if(actor.getId() != memberId) {
+            return RsData.of("F-1", "사용자 정보가 일치하지 않습니다.");
+        }
+
+         Member checkMember = findByNickname(nickname).orElse(null);
+
+        if(checkMember != null) {
+            return RsData.of("F-S", "이미 사용 중인 닉네임입니다.");
+        }
+
+        actor.setNickname(nickname);
+        memberRepository.save(actor);
+
+        return RsData.of("S-1", "닉네임이 수정되었습니다.");
+    }
+
+
     public Optional<Member> findById(Long id) {
         return memberRepository.findById(id);
     }

--- a/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
@@ -36,14 +36,6 @@ public class MemberService {
 
     public void delete(Member member) {memberRepository.delete(member);}
 
-    public Optional<Member> findByUsername(String username) {
-        return memberRepository.findByUsername(username);
-    }
-
-    public Optional<Member> findById(Long id) {
-        return memberRepository.findById(id);
-    }
-
     @Transactional
 
     // 일반 회원가입
@@ -57,6 +49,14 @@ public class MemberService {
 
         if ( findByUsername(username).isPresent() ) {
             return RsData.of("F-1", "해당 아이디(%s)는 이미 사용중입니다.".formatted(username));
+        }
+
+        if ( findByEmail(email).isPresent() ) {
+            return RsData.of("F-2", "해당 이메일(%s)은 이미 사용중입니다.".formatted(email));
+        }
+
+        if ( findByNickname(nickname).isPresent() ) {
+            return RsData.of("F-3", "해당 닉네임(%s)은 이미 사용중입니다.".formatted(nickname));
         }
 
         Member member = Member
@@ -75,6 +75,7 @@ public class MemberService {
     }
 
     // 소셜 로그인
+
     @Transactional
     public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String email, String name, String nickname) {
         Optional<Member> opMember = findByUsername(username);
@@ -83,6 +84,20 @@ public class MemberService {
 
         return join(providerTypeCode, username, "", email, name, nickname); // 최초 로그인시 실행
 
+    }
+
+
+    public Optional<Member> findById(Long id) {
+        return memberRepository.findById(id);
+    }
+    public Optional<Member> findByUsername(String username) {
+        return memberRepository.findByUsername(username);
+    }
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+    public Optional<Member> findByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname);
     }
 
 }

--- a/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/placehub/boundedContext/member/service/MemberService.java
@@ -36,9 +36,8 @@ public class MemberService {
 
     public void delete(Member member) {memberRepository.delete(member);}
 
-    @Transactional
-
     // 일반 회원가입
+    @Transactional
     public RsData<Member> join(String username, String password, String email, String name, String nickname){
         // "PlaceHub" - 일반 회원가입으로 가입한 회원 확인용
         return join("PlaceHub", username, password, email, name, nickname);
@@ -46,18 +45,6 @@ public class MemberService {
 
     @Transactional
     public RsData<Member> join(String providerTypeCode, String username, String password, String email, String name, String nickname) {
-
-        if ( findByUsername(username).isPresent() ) {
-            return RsData.of("F-1", "해당 아이디(%s)는 이미 사용중입니다.".formatted(username));
-        }
-
-        if ( findByEmail(email).isPresent() ) {
-            return RsData.of("F-2", "해당 이메일(%s)은 이미 사용중입니다.".formatted(email));
-        }
-
-        if ( findByNickname(nickname).isPresent() ) {
-            return RsData.of("F-3", "해당 닉네임(%s)은 이미 사용중입니다.".formatted(nickname));
-        }
 
         Member member = Member
                 .builder()
@@ -74,8 +61,23 @@ public class MemberService {
 
     }
 
-    // 소셜 로그인
+    public RsData<Member> checkDuplicateValue(String username, String email, String nickname){
+        if ( findByUsername(username).isPresent() ) {
+            return RsData.of("F-1", "해당 아이디(%s)는 이미 사용중입니다.".formatted(username));
+        }
 
+        if ( findByEmail(email).isPresent() ) {
+            return RsData.of("F-2", "해당 이메일(%s)은 이미 사용중입니다.".formatted(email));
+        }
+
+        if ( findByNickname(nickname).isPresent() ) {
+            return RsData.of("F-3", "해당 닉네임(%s)은 이미 사용중입니다.".formatted(nickname));
+        }
+
+        return RsData.of("S-1", "가입 가능합니다.");
+    }
+
+    // 소셜 로그인
     @Transactional
     public RsData<Member> whenSocialLogin(String providerTypeCode, String username, String email, String name, String nickname) {
         Optional<Member> opMember = findByUsername(username);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
     url: jdbc:mysql://localhost:3306/placehub__dev?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 
   security:
+    csrf:
+      enabled: true
     oauth2:
       client:
         registration:

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko"
+      data-theme="light"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.w3.org/1999/xhtml">
 
@@ -8,6 +9,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css"/>
+
+    <!-- csrf toekn-->
+    <meta name="_csrf" th:content="${_csrf.token}">
+    <meta name="_csrf_header" th:content="${_csrf.headerName}">
 
     <!-- 제이쿼리 불러오기 -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>

--- a/src/main/resources/templates/usr/member/join.html
+++ b/src/main/resources/templates/usr/member/join.html
@@ -51,6 +51,15 @@
                 return;
             }
 
+            // 이메일 유효성 검사
+            var emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+            if (!emailRegex.test(form.email.value)) {
+                toastWarning('유효한 이메일 형식이 아닙니다.');
+                form.email.focus();
+                return;
+            }
+
+
             form.submit(); // 폼 발송
         }
     </script>

--- a/src/main/resources/templates/usr/member/join.html
+++ b/src/main/resources/templates/usr/member/join.html
@@ -59,6 +59,19 @@
                 return;
             }
 
+            form.name.value = form.name.value.trim();
+            if (form.name.value.length == 0) {
+                toastWarning('이름을 입력해주세요.');
+                form.name.focus();
+                return;
+            }
+
+            form.nickname.value = form.nickname.value.trim();
+            if (form.nickname.value.length == 0) {
+                toastWarning('닉네임을 입력해주세요.');
+                form.nickname.focus();
+                return;
+            }
 
             form.submit(); // 폼 발송
         }

--- a/src/main/resources/templates/usr/member/join.html
+++ b/src/main/resources/templates/usr/member/join.html
@@ -88,7 +88,7 @@
                 <input type="text" name="nickname" maxlength="20" placeholder="닉네임" class="input input-bordered">
             </div>
 
-            <div>
+            <div class="form-control">
                 <input type="submit" value="회원가입" class="btn btn-primary">
             </div>
         </form>

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -9,33 +9,30 @@
 
 <body>
 
-
-<script>
-    function LoginForm__submit(form) {
-
-        form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
-
-        if (form.username.value.length == 0) {
-            toastWarning('아이디를 입력해주세요.');
-            form.username.focus();
-            return;
-        }
-
-        form.password.value = form.password.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
-
-        if (form.password.value.length == 0) {
-            form.password.focus();
-            toastWarning('비밀번호를 입력해주세요.');
-            return;
-        }
-
-
-        form.submit(); // 폼 발송
-    }
-</script>
-
-
 <div layout:fragment="content" class="flex-grow flex items-center justify-center">
+
+    <script>
+        function LoginForm__submit(form) {
+
+            form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
+
+            if (form.username.value.length == 0) {
+                toastWarning('아이디를 입력해주세요.');
+                form.username.focus();
+                return;
+            }
+
+            form.password.value = form.password.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
+
+            if (form.password.value.length == 0) {
+                form.password.focus();
+                toastWarning('비밀번호를 입력해주세요.');
+                return;
+            }
+
+            form.submit(); // 폼 발송
+        }
+    </script>
 
     <div class="hero-content flex-col">
 
@@ -46,10 +43,10 @@
         <form th:action method="POST" class="p-10 flex flex-col gap-4"
               onsubmit="LoginForm__submit(this); return false;">
 
-            <div class="form-control">
+            <div>
                 <input type="text" name="username" maxlength="20" placeholder="아이디" class="input input-bordered">
             </div>
-            <div class="form-control">
+            <div>
                 <input type="password" name="password" maxlength="20" placeholder="비밀번호" class="input input-bordered">
             </div>
 

--- a/src/main/resources/templates/usr/member/me.html
+++ b/src/main/resources/templates/usr/member/me.html
@@ -1,22 +1,17 @@
 <html layout:decorate="~{layout}" xmlns:layout="http://www.w3.org/1999/xhtml">
 
 <head>
-    <title>
-        내 정보
-    </title>
+    <title>내 정보</title>
 </head>
 
 <body>
 
-<div layout:fragment="content" class="flex-grow flex items-center justify-center">
+<div layout:fragment="content">
 
-<!-- 내 정보 시작 -->
-<div class="max-w-xl w-full px-4 py-5">
-    <div class="flex flex-col gap-4">
-
-
-        <div class="card flex-shrink-0 shadow-2xl bg-base-100">
-            <div class="card-body">
+    <!-- 내 정보 시작 -->
+    <div class="hero-content flex my-10">
+        <div class="flex flex-col gap-4">
+            <div>
                 <div class="overflow-x-auto">
                     <h2 class="card-title mb-3">
                         <i class="fa-solid fa-user"></i>
@@ -33,7 +28,21 @@
                         </tr>
                         <tr>
                             <td>닉네임</td>
-                            <td><span th:text="${@rq.member.nickname}"></span></td>
+                            <td class="flex flex-col gap-2">
+                                <div id="nicknameContainer" class="flex gap-5">
+                                    <span id="nicknameValue" th:text="${@rq.member.nickname}"></span>
+                                    <button id="editNicknameBtn" class="btn btn-xs btn-outline"
+                                            th:attr="data-member-id=${@rq.member.id}">수정하기
+                                    </button>
+                                </div>
+                                <div id="nicknameUpdateContainer" class="flex mt-1" style="display: none;">
+                                    <input type="text" id="nicknameInput" placeholder="새로운 닉네임"
+                                           class="p-2 max-w-xs rounded-md border border-gray-200">
+                                    <button id="updateNicknameBtn" class="btn btn-xs btn-outline mx-1">수정완료</button>
+                                </div>
+                                <div id="updateNicknameResult" class="mt-1 text-red-400" style="display: none;"></div>
+                            </td>
+
                         </tr>
                         <tr>
                             <td>이메일</td>
@@ -42,7 +51,8 @@
                         <tr>
                             <td>가입날짜</td>
                             <td><i class="fa-regular fa-clock"></i>
-                                <span th:text="${#temporals.format(@rq.member.createDate, 'yy-MM-dd')}"></span>
+                                <span th:text="${#temporals.format(@rq.member.createDate,
+                                        'yy-MM-dd')}"></span>
                             </td>
                         </tr>
                     </table>
@@ -51,7 +61,78 @@
         </div>
         <!-- 내 정보 끝 -->
     </div>
-    </div>
+
+    <script>
+        const editNicknameBtn = document.getElementById("editNicknameBtn");
+        const nicknameUpdateContainer = document.getElementById("nicknameUpdateContainer");
+        const nicknameValue = document.getElementById("nicknameValue");
+        const nicknameInput = document.getElementById("nicknameInput");
+        const updateNicknameBtn = document.getElementById("updateNicknameBtn");
+        const memberId = editNicknameBtn.getAttribute("data-member-id");
+        const updateNicknameResult = document.getElementById("updateNicknameResult");
+
+        // csrf 토큰
+        var csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+        var csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
+
+        // 수정하기 버튼 클릭 시
+        editNicknameBtn.addEventListener("click", () => {
+            nicknameUpdateContainer.style.display = "block";
+            editNicknameBtn.style.display = "none";
+            nicknameInput.value = nicknameValue.textContent;
+        });
+
+        // 수정된 닉네임을 페이지에 반영
+        function updateNicknameDisplay(newNickname) {
+            const nicknameValue = document.getElementById("nicknameValue");
+            nicknameValue.textContent = newNickname;
+        }
+
+        // 수정 완료 버튼 클릭 시
+        updateNicknameBtn.addEventListener("click", () => {
+            const newNickname = nicknameInput.value;
+
+            // 내용을 입력하지 않은 경우
+            if (!newNickname) {
+                updateNicknameResult.style.display = "block";
+                updateNicknameResult.textContent = "변경할 닉네임을 입력해주세요.";
+                return;
+            }
+
+            // 기존 닉네임과 같은 닉네임을 입력한 경우
+            if (newNickname === nicknameValue.textContent) {
+                updateNicknameResult.style.display = "block";
+                updateNicknameResult.textContent = "새로운 닉네임을 입력해주세요.";
+                return;
+            }
+
+            const endpoint = `/member/update/nickname/${memberId}`;
+
+            const xhr = new XMLHttpRequest();
+            xhr.open("POST", endpoint);
+            xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+            xhr.setRequestHeader(csrfHeader, csrfToken);
+            xhr.onreadystatechange = function () {
+                if (xhr.readyState === XMLHttpRequest.DONE) {
+                    const response = JSON.parse(xhr.responseText);
+                    const returnMessage = response.message;
+
+                    if (xhr.status === 200) {
+                        toastNotice(returnMessage);
+                        updateNicknameDisplay(newNickname); // 수정된 닉네임 반영
+                    } else {
+                        toastWarning(returnMessage);
+                    }
+                }
+            };
+            xhr.send("nickname=" + encodeURIComponent(newNickname));
+            nicknameUpdateContainer.style.display = "none";
+            updateNicknameResult.style.display = "none";
+            editNicknameBtn.style.display = "block";
+        });
+    </script>
+
 </div>
 </body>
+
 </html>


### PR DESCRIPTION
#### 추가된 내용
- 회원가입 시 이메일 유효성 검사
- 회원가입 시 이름, 닉네임 필수
- 일반 회원가입 시 이메일, 닉네임 중복 불가
- 최초 소셜 로그인 닉네임은 아이디와 동일하게
- 닉네임 수정 - ajax
   - 권한 및 중복 체크

#### 변경사항


#### 특이사항
- 소셜 로그인시 이미 가입된 이메일과 동일한 이메일이면 가입 불가 기능 구현 필요

close #49 